### PR TITLE
Fixes for listing and discovery of devices/formats

### DIFF
--- a/pygrabber/dshow_graph.py
+++ b/pygrabber/dshow_graph.py
@@ -131,16 +131,17 @@ class VideoInput(Filter):
         result = []
         for i in range(0, media_types_count):
             media_type, capability = stream_config.GetStreamCaps(i)
-            p_video_info_header = cast(media_type.contents.pbFormat, POINTER(VIDEOINFOHEADER))
-            bmp_header = p_video_info_header.contents.bmi_header
-            result.append({
-                'index': i,
-                'media_type_str': subtypes[str(media_type.contents.subtype)],
-                'width': bmp_header.biWidth,
-                'height': bmp_header.biHeight,
-                'min_framerate': 10000000 / capability.MinFrameInterval,
-                'max_framerate': 10000000 / capability.MaxFrameInterval
-            })
+            if GUID(FormatTypes.FORMAT_VideoInfo) == media_type.contents.formattype:
+                p_video_info_header = cast(media_type.contents.pbFormat, POINTER(VIDEOINFOHEADER))
+                bmp_header = p_video_info_header.contents.bmi_header
+                result.append({
+                    'index': i,
+                    'media_type_str': subtypes[str(media_type.contents.subtype)],
+                    'width': bmp_header.biWidth,
+                    'height': bmp_header.biHeight,
+                    'min_framerate': 10000000 / capability.MinFrameInterval,
+                    'max_framerate': 10000000 / capability.MaxFrameInterval
+                })
             #print(f"{capability.MinOutputSize.cx}x{capability.MinOutputSize.cx} - {capability.MaxOutputSize.cx}x{capability.MaxOutputSize.cx}")
         return result
 

--- a/pygrabber/dshow_graph.py
+++ b/pygrabber/dshow_graph.py
@@ -227,7 +227,10 @@ class SystemDeviceEnum:
 
     def get_available_filters(self, category_clsid):
         filter_enumerator = self.system_device_enum.CreateClassEnumerator(GUID(category_clsid), dwFlags=0)
-        moniker, count = filter_enumerator.Next(1)
+        try:
+            moniker, count = filter_enumerator.Next(1)
+        except ValueError:
+            return []
         result = []
         while count > 0:
             result.append(get_moniker_name(moniker))

--- a/pygrabber/dshow_ids.py
+++ b/pygrabber/dshow_ids.py
@@ -41,6 +41,16 @@ class clsids:
     CLSID_SmartTee                 = "{CC58E280-8AA1-11d1-B3F1-00AA003761C5}"
 
 
+class FormatTypes:
+    FORMAT_None = "{0F6417D6-C318-11D0-A43F-00A0C9223196}"
+    FORMAT_VideoInfo = "{05589f80-c356-11ce-bf01-00aa0055595a}"
+    FORMAT_VideoInfo2 = "{F72A76A0-EB0A-11d0-ACE4-0000C0CC16BA}"
+    FORMAT_WaveFormatEx = "{05589f81-c356-11ce-bf01-00aa0055595a}"
+    FORMAT_MPEGVideo = "{05589f82-c356-11ce-bf01-00aa0055595a}"
+    FORMAT_MPEGStreams = "{05589f83-c356-11ce-bf01-00aa0055595a}"
+    FORMAT_DvInfo = "{05589f84-c356-11ce-bf01-00aa0055595a}"
+    FORMAT_525WSS = "{C7ECF04D-4582-4869-9ABB-BFB523B62EDF}"
+
 class DeviceCategories:
     VideoInputDevice = "{860bb310-5d01-11d0-bd3b-00a0c911ce86}"
     AudioInputDevice = "{33d9a762-90c8-11d0-bd43-00a0c911ce86}"


### PR DESCRIPTION
- Some cameras return both VIDEOINFO and VIDEOINFO2 entries for the same formats, resulting in badly parsed VIDEOINFO2 entries.
- When no camera is plugged, the filter_enumerator contains a null, causing an exception. This catches it and returns an empty list.
